### PR TITLE
Add dark mode toggle

### DIFF
--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button'
 import Link from 'next/link'
 import { format } from 'date-fns'
 import { motion } from 'framer-motion'
+import ThemeToggle from '@/components/theme-toggle'
 
 interface DashboardData {
   overview: {
@@ -126,8 +127,9 @@ export default function AnalyticsPage() {
                 <p className="text-gray-600 dark:text-gray-400 mt-1">CMU Health Services Chatbot Metrics</p>
               </div>
             </div>
-            <div className="text-sm text-gray-500">
-              Last updated: {new Date().toLocaleTimeString()}
+            <div className="flex items-center space-x-4 text-sm text-gray-500">
+              <span>Last updated: {new Date().toLocaleTimeString()}</span>
+              <ThemeToggle />
             </div>
           </div>
         </div>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ThemeProvider from "@/components/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,7 +29,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         suppressHydrationWarning
       >
-        {children}
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Heart, Send, Upload, Activity, Clock, Phone, MapPin, FileText, Sparkles, Bot, User, BarChart3 } from 'lucide-react'
+import ThemeToggle from '@/components/theme-toggle'
 import { motion, AnimatePresence } from 'framer-motion'
 import Image from 'next/image'
 
@@ -140,8 +141,8 @@ export default function Home() {
               </div>
             </div>
             <div className="flex items-center space-x-4">
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 className="flex items-center space-x-2"
                 onClick={() => window.location.href = '/analytics'}
               >
@@ -156,6 +157,7 @@ export default function Home() {
                 <Clock className="h-4 w-4" />
                 <span>Mon-Fri: 8:30 AM - 5:00 PM</span>
               </Button>
+              <ThemeToggle />
             </div>
           </div>
         </div>

--- a/frontend/src/components/theme-provider.tsx
+++ b/frontend/src/components/theme-provider.tsx
@@ -1,0 +1,17 @@
+'use client'
+import { useEffect } from 'react'
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const stored = localStorage.getItem('theme')
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    const theme = stored || (prefersDark ? 'dark' : 'light')
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  }, [])
+
+  return <>{children}</>
+}

--- a/frontend/src/components/theme-toggle.tsx
+++ b/frontend/src/components/theme-toggle.tsx
@@ -1,0 +1,37 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { Moon, Sun } from 'lucide-react'
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem('theme') as 'light' | 'dark') || 'light'
+    }
+    return 'light'
+  })
+
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', theme)
+    }
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'))
+  }
+
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label="Toggle Dark Mode"
+      className="rounded-md border p-2 hover:bg-gray-100 dark:hover:bg-gray-800"
+    >
+      {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- create theme provider and toggle component
- integrate dark mode toggle in home and analytics pages
- wrap layout in theme provider

## Testing
- `npm run build` *(fails: `<Html> should not be imported outside of pages/_document`)*
- `./gradlew test` *(fails: could not determine Java dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6863a526369c832ea747ee975665bd14